### PR TITLE
Add JWT expiry

### DIFF
--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -144,6 +144,10 @@ spec:
               value: {{ .Values.workers.accessKeyId | quote }}
             - name: conductor.security.default.workers.accessKeySecret
               value: {{ .Values.workers.accessKeySecret | quote }}
+            {{- if .Values.security.jwtExpiry }}
+            - name: conductor.security.jwt.exp
+              value: {{ .Values.security.jwtExpiry | quote }}
+            {{- end }}
             - name: conductor.security.jwt.secret
               valueFrom:
                 secretKeyRef:
@@ -361,6 +365,10 @@ spec:
               value: {{ .Values.workers.accessKeyId | quote }}
             - name: conductor.security.client.secret
               value: {{ .Values.workers.accessKeySecret | quote }}
+            {{- if .Values.security.jwtExpiry }}
+            - name: conductor.security.token.refresh.interval
+              value: {{ .Values.security.jwtExpiry | quote }}
+            {{- end }}
             {{- end }}
             - name: LOCAL_HOST_IP
               valueFrom:

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -110,6 +110,7 @@ security:
   enabled: false
   overwriteDefault: true
   createUserOnAuthentication: false
+  jwtExpiry: 3600
 # Please note that the admin user has to login first and create this group
   defaultUserGroupsOnCreate: all_users
   defaultUserEmail:


### PR DESCRIPTION
- Introduce new field `security.jwtExpiry` in values.yaml with default of `3600`
- Map field to:
  - Server: `conductor.security.jwt.exp`
  - Worker: `conductor.security.token.refresh.interval`