### PR TITLE
Added missing aws.region env in worker

### DIFF
--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -342,6 +342,8 @@ spec:
         - env:
             - name: DEPLOY_ENV
               value: prod
+            - name: aws.region
+              value: {{ .Values.app.s3Region | quote }}
             - name: JVM_MEMORY_SETTINGS
               value: {{ .Values.workers.jvmSettings | quote }}
             - name: SPRING_PROFILES_ACTIVE


### PR DESCRIPTION
SSM fails in worker because of missing `aws.region` env var in worker deployment