### PR TITLE
Haven/5.2.12

### DIFF
--- a/charts/orkes-conductor/Chart.yaml
+++ b/charts/orkes-conductor/Chart.yaml
@@ -5,4 +5,4 @@ description: Orkes Conductor
 type: application
 
 version: 2.7.35
-appVersion: "5.2.10"
+appVersion: "5.2.12"

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -389,7 +389,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             {{- if .Values.workers.env }}
-            {{- range $key, $value := .Values.conductor.env }}
+            {{- range $key, $value := .Values.workers.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -278,6 +278,14 @@ spec:
             - name: conductor.grpc.enabled
               value: {{ .Values.app.grpcServerEnabled | quote }}
             #### Others ####
+            - name: conductor.postgres.workflowDefCacheRefreshInterval
+              value: {{ .Values.app.workflowDefinitionCache.refreshIntervalInSeconds | quote }}
+            - name: conductor.postgres.workflowDefCacheMaxSize
+              value: {{ .Values.app.workflowDefinitionCache.maxSize | quote }}
+            - name: conductor.postgres.taskDefCacheRefreshInterval
+              value: {{ .Values.app.taskDefinitionCache.refreshIntervalInSeconds | quote }}
+            - name: conductor.postgres.taskDefCacheMaxSize
+              value: {{ .Values.app.taskDefinitionCache.maxSize | quote }}
             - name: conductor.swagger.url
               value: {{ .Values.app.swaggerUrl | quote }}
             - name: conductor.app.lockTimeToTry

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
             - name: conductor.queue.type
               value: redis_cluster
             {{- end }}
+            {{- if .Values.redis.username }}
+            - name: conductor.redis.user
+              value: {{ .Values.redis.username | quote }}
+            {{- end }}
             #### Postgres ####
             - name: conductor.persistence.type
               value: {{ .Values.conductor.persistence.type | quote }}

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -56,6 +56,12 @@ app:
     memoryLimit: "3Gi"
     cpuRequests: "2"
     memoryRequests: "2Gi"
+  workflowDefinitionCache:
+    refreshIntervalInSeconds: 0 # 0 means disabled
+    maxSize: 1000
+  taskDefinitionCache:
+    refreshIntervalInSeconds: 60 # Task definitions are cached by default
+    maxSize: 1000
 
 # Provide the name of the key vault if you are using key vault for secret management
 # Pre-requisite - the Azure SDK used by Conductor expects the host (i.e. pod/container) to be able to access this vault

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -57,10 +57,10 @@ app:
     cpuRequests: "2"
     memoryRequests: "2Gi"
   workflowDefinitionCache:
-    refreshIntervalInSeconds: 0 # 0 means disabled
+    refreshIntervalInSeconds: 0  # 0 means disabled
     maxSize: 1000
   taskDefinitionCache:
-    refreshIntervalInSeconds: 60 # Task definitions are cached by default
+    refreshIntervalInSeconds: 60  # Task definitions are cached by default
     maxSize: 1000
 
 # Provide the name of the key vault if you are using key vault for secret management


### PR DESCRIPTION
- Fix worker env passthrough
- Allow specifying redis user via value
- Update conductor version to 5.2.12
- Add workflow and task definition cache parameters