### PR TITLE
Add GCP secret support, annotations, fix helm lint

### DIFF
--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -82,8 +82,10 @@ spec:
               value: {{ .Values.app.jvmSettings | quote }}
             - name: SPRING_PROFILES_ACTIVE
               value: {{ .Values.app.springProfilesActive | quote }}
+            {{- if .Values.azureKeyVaultName }}
             - name: azure.keyvault.name
               value: {{ .Values.azureKeyVaultName | quote }}
+            {{- end }}
             #### Redis ####
             {{- if eq $secretsType "gcp" }}
             - name: conductor.redis.hosts

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -84,11 +84,16 @@ spec:
             - name: azure.keyvault.name
               value: {{ .Values.azureKeyVaultName | quote }}
             #### Redis ####
+            {{- if eq $secretsType "gcp" }}
+            - name: conductor.redis.hosts
+              value: {{ $redisHosts | quote }}
+            {{- else }}
             - name: conductor.redis.hosts
               valueFrom:
                 secretKeyRef:
                   name: orkesdeploymentsecrets
                   key: redisHosts
+            {{- end }}
             - name: conductor.redis.zone
               value: {{ .Values.redis.zoneSuffix | default "us-east-1c" | quote }}
             - name: conductor.redis.ssl
@@ -98,6 +103,12 @@ spec:
             - name: conductor.redis.database
               value: {{ .Values.redis.dbIndex | quote }}
             {{- if .Values.redis.password }}
+            {{- if eq $secretsType "gcp" }}
+            - name: conductor.redis.password
+              value: {{ .Values.redis.password | quote }}
+            - name: conductor.redis-lock.serverPassword
+              value: {{ .Values.redis.password | quote }}
+            {{- else }}
             - name: conductor.redis.password
               valueFrom:
                 secretKeyRef:
@@ -108,6 +119,7 @@ spec:
                 secretKeyRef:
                   name: orkesdeploymentsecrets
                   key: redisPassword
+            {{- end }}
             {{- end }}
             {{- if $clusterMode }}
             - name: conductor.db.type
@@ -124,11 +136,16 @@ spec:
               value: {{ .Values.conductor.persistence.type | quote }}
             - name: spring.datasource.url
               value: {{ .Values.postgres.url | quote }}
+            {{- if eq $secretsType "gcp" }}
+            - name: spring.datasource.password
+              value: {{ .Values.postgres.password | quote }}
+            {{- else }}
             - name: spring.datasource.password
               valueFrom:
                 secretKeyRef:
                   name: orkesdeploymentsecrets
                   key: postgresPassword
+            {{- end }}
             - name: spring.datasource.username
               value: {{ .Values.postgres.username | quote }}
             {{- if .Values.app.customLogoUrl }}
@@ -161,22 +178,32 @@ spec:
             - name: conductor.security.jwt.exp
               value: {{ .Values.security.jwtExpiry | quote }}
             {{- end }}
+            {{- if eq $secretsType "gcp" }}
+            - name: conductor.security.jwt.secret
+              value: {{ .Values.security.jwt.secret | quote }}
+            {{- else }}
             - name: conductor.security.jwt.secret
               valueFrom:
                 secretKeyRef:
                   name: orkesdeploymentsecrets
                   key: securityJwtSecret
+            {{- end }}
             {{- if .Values.security.auth0 }}
             #### Security - Auth0 ####
             - name: conductor.security.auth0.clientId
               value: {{ .Values.security.auth0.clientId | quote }}
             {{- if .Values.security.auth0.clientSecret }}
+            {{- if eq $secretsType "gcp" }}
+            - name: conductor.security.auth0.clientSecret
+              value: {{ .Values.security.auth0.clientSecret | quote }}
+            {{- else }}
             - name: conductor.security.auth0.clientSecret
               valueFrom:
                 secretKeyRef:
                   name: orkesdeploymentsecrets
                   key: auth0ClientSecret
-              {{- end }}
+            {{- end }}
+            {{- end }}
             - name: conductor.security.auth0.useIdToken
               value: {{ ne (toString .Values.security.auth0.useIdToken) "false" | quote }}
             - name: conductor.security.auth0.domain
@@ -270,6 +297,10 @@ spec:
             {{- if .Values.secrets.ssmPath }}
             - name: conductor.secrets.ssm.path
               value: {{ .Values.secrets.ssmPath | quote }}
+            {{- end }}
+            {{- if .Values.secrets.gsmPath }}
+            - name: conductor.secrets.gsm.path
+              value: {{ .Values.secrets.gsmPath | quote }}
             {{- end }}
             #### Limits ####
             - name: conductor.limits.maxWorkflowSizeInMiB

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -46,6 +46,7 @@
 {{- $appReplicaCount := .Values.app.replicaCount | default .Values.replicaCount -}}
 {{- $validation := $appReplicaCount | required "replicaCount (deprecated) or app.replicaCount is required." -}}
 {{- $secretsType := .Values.secrets.type | default .Values.app.secretsType -}}
+{{- $useCloudSecrets := or (eq $secretsType "gcp") (or (eq $secretsType "ssm") (eq $secretsType "azkv")) -}}
 {{- $validation := $secretsType | required "app.secretsType (deprecated) or secrets.type is required." -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -87,7 +88,7 @@ spec:
               value: {{ .Values.azureKeyVaultName | quote }}
             {{- end }}
             #### Redis ####
-            {{- if eq $secretsType "gcp" }}
+            {{- if $useCloudSecrets }}
             - name: conductor.redis.hosts
               value: {{ $redisHosts | quote }}
             {{- else }}
@@ -97,8 +98,6 @@ spec:
                   name: orkesdeploymentsecrets
                   key: redisHosts
             {{- end }}
-            - name: conductor.redis.zone
-              value: {{ .Values.redis.zoneSuffix | default "us-east-1c" | quote }}
             - name: conductor.redis.ssl
               value: {{ .Values.redis.ssl | quote }}
             - name: conductor.redis-lock.serverAddress
@@ -106,7 +105,7 @@ spec:
             - name: conductor.redis.database
               value: {{ .Values.redis.dbIndex | quote }}
             {{- if .Values.redis.password }}
-            {{- if eq $secretsType "gcp" }}
+            {{- if $useCloudSecrets }}
             - name: conductor.redis.password
               value: {{ .Values.redis.password | quote }}
             - name: conductor.redis-lock.serverPassword
@@ -139,7 +138,7 @@ spec:
               value: {{ .Values.conductor.persistence.type | quote }}
             - name: spring.datasource.url
               value: {{ .Values.postgres.url | quote }}
-            {{- if eq $secretsType "gcp" }}
+            {{- if $useCloudSecrets }}
             - name: spring.datasource.password
               value: {{ .Values.postgres.password | quote }}
             {{- else }}
@@ -181,7 +180,7 @@ spec:
             - name: conductor.security.jwt.exp
               value: {{ .Values.security.jwtExpiry | quote }}
             {{- end }}
-            {{- if eq $secretsType "gcp" }}
+            {{- if $useCloudSecrets }}
             - name: conductor.security.jwt.secret
               value: {{ .Values.security.jwt.secret | quote }}
             {{- else }}
@@ -196,7 +195,7 @@ spec:
             - name: conductor.security.auth0.clientId
               value: {{ .Values.security.auth0.clientId | quote }}
             {{- if .Values.security.auth0.clientSecret }}
-            {{- if eq $secretsType "gcp" }}
+            {{- if $useCloudSecrets }}
             - name: conductor.security.auth0.clientSecret
               value: {{ .Values.security.auth0.clientSecret | quote }}
             {{- else }}

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -345,7 +345,7 @@ spec:
                   fieldPath: status.podIP
             {{- if .Values.conductor.env }}
             {{- range $key, $value := .Values.conductor.env }}
-            - name: {{ $key | replace "." "__DOT__" | replace "[" "__LB__" | replace "]" "__RB__" }}
+            - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
@@ -444,12 +444,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            {{- if .Values.workers.env }}
-            {{- range $key, $value := .Values.workers.env }}
+            {{- if .Values.conductor.env }}
+            {{- range $key, $value := .Values.conductor.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- range $key, $value := .Values.conductor.env }}
+            {{- end }}
+            {{- if .Values.workers.env }}
+            {{- range $key, $value := .Values.workers.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -33,7 +33,8 @@
   {{- $validation := .Values.app.documentStoreAzureBlobEndpoint | required "app.documentStoreAzureBlobEndpoint is required." -}}
   {{- $validation := .Values.app.documentStoreAzureUseSASToken | required "app.documentStoreAzureUseSASToken is required." -}}
 {{- end -}}
-{{- $redisHosts := printf "%v:%v:%v" .Values.redis.host .Values.redis.port "us-east-1c" -}}
+{{- $redisZone := .Values.redis.zoneSuffix | default "us-east-1c" -}}
+{{- $redisHosts := printf "%v:%v:%v" .Values.redis.host .Values.redis.port $redisZone -}}
 {{- if .Values.redis.password -}}
   {{- $redisHosts = printf "%v:%v" $redisHosts .Values.redis.password -}}
 {{- end -}}

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             - name: JVM_MEMORY_SETTINGS
               value: {{ .Values.app.jvmSettings | quote }}
             - name: SPRING_PROFILES_ACTIVE
-              value: {{ .Values.app.springProfilesActive | quote }}
+              value: {{ printf "%s%s" (ternary "security," "" $securityEnabled) .Values.app.springProfilesActive | quote }}
             {{- if .Values.azureKeyVaultName }}
             - name: azure.keyvault.name
               value: {{ .Values.azureKeyVaultName | quote }}
@@ -413,7 +413,7 @@ spec:
             - name: JVM_MEMORY_SETTINGS
               value: {{ .Values.workers.jvmSettings | quote }}
             - name: SPRING_PROFILES_ACTIVE
-              value: {{ .Values.workers.springProfilesActive | quote }}
+              value: {{ printf "%s%s" (ternary "security," "" $securityEnabled) .Values.workers.springProfilesActive | quote }}
             - name: conductor.worker.http.block.hosts
               value: localhost
             - name: conductor.worker.http.block.ips

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: JVM_MEMORY_SETTINGS
               value: {{ .Values.app.jvmSettings | quote }}
             - name: SPRING_PROFILES_ACTIVE
-              value: {{ printf "%s%s" (ternary "security," "" $securityEnabled) .Values.app.springProfilesActive | quote }}
+              value: {{ .Values.app.springProfilesActive | quote }}
             - name: azure.keyvault.name
               value: {{ .Values.azureKeyVaultName | quote }}
             #### Redis ####
@@ -89,17 +89,26 @@ spec:
                 secretKeyRef:
                   name: orkesdeploymentsecrets
                   key: redisHosts
+            - name: conductor.redis.zone
+              value: {{ .Values.redis.zoneSuffix | default "us-east-1c" | quote }}
             - name: conductor.redis.ssl
               value: {{ .Values.redis.ssl | quote }}
             - name: conductor.redis-lock.serverAddress
               value: {{ $redisLockServerAddress | quote }}
             - name: conductor.redis.database
               value: {{ .Values.redis.dbIndex | quote }}
+            {{- if .Values.redis.password }}
+            - name: conductor.redis.password
+              valueFrom:
+                secretKeyRef:
+                  name: orkesdeploymentsecrets
+                  key: redisPassword
             - name: conductor.redis-lock.serverPassword
               valueFrom:
                 secretKeyRef:
                   name: orkesdeploymentsecrets
                   key: redisPassword
+            {{- end }}
             {{- if $clusterMode }}
             - name: conductor.db.type
               value: redis_cluster
@@ -304,7 +313,7 @@ spec:
                   fieldPath: status.podIP
             {{- if .Values.conductor.env }}
             {{- range $key, $value := .Values.conductor.env }}
-            - name: {{ $key }}
+            - name: {{ $key | replace "." "__DOT__" | replace "[" "__LB__" | replace "]" "__RB__" }}
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
@@ -371,7 +380,7 @@ spec:
             - name: JVM_MEMORY_SETTINGS
               value: {{ .Values.workers.jvmSettings | quote }}
             - name: SPRING_PROFILES_ACTIVE
-              value: {{ printf "%s%s" (ternary "security," "" $securityEnabled) .Values.workers.springProfilesActive | quote }}
+              value: {{ .Values.workers.springProfilesActive | quote }}
             - name: conductor.worker.http.block.hosts
               value: localhost
             - name: conductor.worker.http.block.ips
@@ -384,8 +393,11 @@ spec:
             - name: conductor.worker.http.customcerts.password
               value: {{ .Values.jksFilePassword | quote }}
             {{- end }}
+            {{- $overrideServerUrl := and .Values.workers.env (hasKey .Values.workers.env "conductor.server.url") -}}
+            {{- if not $overrideServerUrl }}
             - name: conductor.server.url
               value: http://{{ include "orkes-conductor.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000/api/
+            {{- end }}
             {{- if $securityEnabled }}
             - name: conductor.security.client.key-id
               value: {{ .Values.workers.accessKeyId | quote }}
@@ -402,6 +414,10 @@ spec:
                   fieldPath: status.podIP
             {{- if .Values.workers.env }}
             {{- range $key, $value := .Values.workers.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range $key, $value := .Values.conductor.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -430,6 +430,9 @@ spec:
             - name: conductor.server.url
               value: http://{{ include "orkes-conductor.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000/api/
             {{- end }}
+            # Ensure workers can resolve GSM/SSM placeholders like ${gsm:...}
+            - name: conductor.secrets.type
+              value: {{ $secretsType | quote }}
             {{- if $securityEnabled }}
             - name: conductor.security.client.key-id
               value: {{ .Values.workers.accessKeyId | quote }}
@@ -444,12 +447,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            {{- if .Values.conductor.env }}
-            {{- range $key, $value := .Values.conductor.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
             {{- if .Values.workers.env }}
             {{- range $key, $value := .Values.workers.env }}
             - name: {{ $key }}

--- a/charts/orkes-conductor/templates/grpcService.yaml
+++ b/charts/orkes-conductor/templates/grpcService.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     serviceName: {{ include "orkes-conductor.fullname" . }}-grpc
     {{- include "orkes-conductor.labels" . | nindent 4 }}-grpc
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/orkes-conductor/templates/secret.yaml
+++ b/charts/orkes-conductor/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.useOrkesDeploymentSecrets -}}
+{{- $secretsType := .Values.secrets.type | default .Values.app.secretsType -}}
+{{- if and .Values.useOrkesDeploymentSecrets (ne $secretsType "gcp") -}}
 {{- $isCluster := eq (toString .Values.redis.clusterMode) "true" -}}
 {{- $zone := .Values.redis.zoneSuffix | default "us-east-1c" -}}
 {{- $redisHosts := printf "%v:%v:%v" .Values.redis.host .Values.redis.port $zone -}}

--- a/charts/orkes-conductor/templates/secret.yaml
+++ b/charts/orkes-conductor/templates/secret.yaml
@@ -1,5 +1,6 @@
 {{- $secretsType := .Values.secrets.type | default .Values.app.secretsType -}}
-{{- if and .Values.useOrkesDeploymentSecrets (ne $secretsType "gcp") -}}
+{{- $useCloudSecrets := or (eq $secretsType "gcp") (or (eq $secretsType "ssm") (eq $secretsType "azkv")) -}}
+{{- if and .Values.useOrkesDeploymentSecrets (not $useCloudSecrets) -}}
 {{- $isCluster := eq (toString .Values.redis.clusterMode) "true" -}}
 {{- $zone := .Values.redis.zoneSuffix | default "us-east-1c" -}}
 {{- $redisHosts := printf "%v:%v:%v" .Values.redis.host .Values.redis.port $zone -}}

--- a/charts/orkes-conductor/templates/secret.yaml
+++ b/charts/orkes-conductor/templates/secret.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.useOrkesDeploymentSecrets -}}
-{{- $redisHosts := printf "%v:%v:%v" .Values.redis.host .Values.redis.port "us-east-1c" -}}
+{{- $isCluster := eq (toString .Values.redis.clusterMode) "true" -}}
+{{- $zone := .Values.redis.zoneSuffix | default "us-east-1c" -}}
+{{- $redisHosts := printf "%v:%v:%v" .Values.redis.host .Values.redis.port $zone -}}
 {{- if .Values.redis.password -}}
   {{- $redisHosts = printf "%v:%v" $redisHosts .Values.redis.password -}}
 {{- end -}}

--- a/charts/orkes-conductor/templates/service-accounts.yaml
+++ b/charts/orkes-conductor/templates/service-accounts.yaml
@@ -4,10 +4,10 @@ metadata:
   name: conductor-app
   labels:
     {{- include "orkes-conductor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- with (and .Values.serviceAccount .Values.serviceAccount.annotations (index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account")) }}
-    iam.gke.io/gcp-service-account: {{ . | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,7 +15,7 @@ metadata:
   name: conductor-workers-app
   labels:
     {{- include "orkes-conductor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- with (and .Values.serviceAccount .Values.serviceAccount.annotations (index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account")) }}
-    iam.gke.io/gcp-service-account: {{ . | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/orkes-conductor/templates/service-accounts.yaml
+++ b/charts/orkes-conductor/templates/service-accounts.yaml
@@ -5,17 +5,8 @@ metadata:
   labels:
     {{- include "orkes-conductor.labels" . | nindent 4 }}
   annotations:
-    {{- $gsa := "" -}}
-    {{- if and .Values.serviceAccount .Values.serviceAccount.annotations -}}
-      {{- $flat := (index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account") -}}
-      {{- if $flat -}}{{- $gsa = $flat -}}{{- end -}}
-      {{- if and (not $gsa) .Values.serviceAccount.annotations.iam .Values.serviceAccount.annotations.iam.gke -}}
-        {{- $nested := (index .Values.serviceAccount.annotations.iam.gke "io/gcp-service-account") -}}
-        {{- if $nested -}}{{- $gsa = $nested -}}{{- end -}}
-      {{- end -}}
-    {{- end -}}
-    {{- if $gsa }}
-    iam.gke.io/gcp-service-account: {{ $gsa | quote }}
+    {{- with (and .Values.serviceAccount .Values.serviceAccount.annotations (index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account")) }}
+    iam.gke.io/gcp-service-account: {{ . | quote }}
     {{- end }}
 ---
 apiVersion: v1
@@ -25,15 +16,6 @@ metadata:
   labels:
     {{- include "orkes-conductor.labels" . | nindent 4 }}
   annotations:
-    {{- $gsa := "" -}}
-    {{- if and .Values.serviceAccount .Values.serviceAccount.annotations -}}
-      {{- $flat := (index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account") -}}
-      {{- if $flat -}}{{- $gsa = $flat -}}{{- end -}}
-      {{- if and (not $gsa) .Values.serviceAccount.annotations.iam .Values.serviceAccount.annotations.iam.gke -}}
-        {{- $nested := (index .Values.serviceAccount.annotations.iam.gke "io/gcp-service-account") -}}
-        {{- if $nested -}}{{- $gsa = $nested -}}{{- end -}}
-      {{- end -}}
-    {{- end -}}
-    {{- if $gsa }}
-    iam.gke.io/gcp-service-account: {{ $gsa | quote }}
+    {{- with (and .Values.serviceAccount .Values.serviceAccount.annotations (index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account")) }}
+    iam.gke.io/gcp-service-account: {{ . | quote }}
     {{- end }}

--- a/charts/orkes-conductor/templates/service-accounts.yaml
+++ b/charts/orkes-conductor/templates/service-accounts.yaml
@@ -4,6 +4,19 @@ metadata:
   name: conductor-app
   labels:
     {{- include "orkes-conductor.labels" . | nindent 4 }}
+  annotations:
+    {{- $gsa := "" -}}
+    {{- if and .Values.serviceAccount .Values.serviceAccount.annotations -}}
+      {{- $flat := (index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account") -}}
+      {{- if $flat -}}{{- $gsa = $flat -}}{{- end -}}
+      {{- if and (not $gsa) .Values.serviceAccount.annotations.iam .Values.serviceAccount.annotations.iam.gke -}}
+        {{- $nested := (index .Values.serviceAccount.annotations.iam.gke "io/gcp-service-account") -}}
+        {{- if $nested -}}{{- $gsa = $nested -}}{{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $gsa }}
+    iam.gke.io/gcp-service-account: {{ $gsa | quote }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -11,3 +24,16 @@ metadata:
   name: conductor-workers-app
   labels:
     {{- include "orkes-conductor.labels" . | nindent 4 }}
+  annotations:
+    {{- $gsa := "" -}}
+    {{- if and .Values.serviceAccount .Values.serviceAccount.annotations -}}
+      {{- $flat := (index .Values.serviceAccount.annotations "iam.gke.io/gcp-service-account") -}}
+      {{- if $flat -}}{{- $gsa = $flat -}}{{- end -}}
+      {{- if and (not $gsa) .Values.serviceAccount.annotations.iam .Values.serviceAccount.annotations.iam.gke -}}
+        {{- $nested := (index .Values.serviceAccount.annotations.iam.gke "io/gcp-service-account") -}}
+        {{- if $nested -}}{{- $gsa = $nested -}}{{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $gsa }}
+    iam.gke.io/gcp-service-account: {{ $gsa | quote }}
+    {{- end }}

--- a/charts/orkes-conductor/templates/service.yaml
+++ b/charts/orkes-conductor/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "orkes-conductor.fullname" . }}
   labels:
     {{- include "orkes-conductor.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -21,6 +25,10 @@ metadata:
   labels:
     serviceName: {{ include "orkes-conductor.fullname" . }}-app
     {{- include "orkes-conductor.labels" . | nindent 4 }}-app
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/orkes-conductor/values.schema.json
+++ b/charts/orkes-conductor/values.schema.json
@@ -76,9 +76,14 @@
             "ssm"
           ]
         },
-        "gsmPath": {
-          "type": "string"
-        }
+        "ssmPath": { "type": "string" },
+        "gsmPath": { "type": "string" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": { "type": "object" }
       }
     },
     "workers": {

--- a/charts/orkes-conductor/values.schema.json
+++ b/charts/orkes-conductor/values.schema.json
@@ -57,6 +57,7 @@
           "type": "string",
           "enum": [
             "azkv",
+            "gcp",
             "memory",
             "ssm"
           ]
@@ -70,6 +71,7 @@
           "type": "string",
           "enum": [
             "azkv",
+            "gcp",
             "memory",
             "ssm"
           ]

--- a/charts/orkes-conductor/values.schema.json
+++ b/charts/orkes-conductor/values.schema.json
@@ -75,6 +75,9 @@
             "memory",
             "ssm"
           ]
+        },
+        "gsmPath": {
+          "type": "string"
         }
       }
     },

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -96,6 +96,7 @@ redis:
   password:
   dbIndex: 0
   clusterMode: false
+  zoneSuffix: us-east-1c
 
 postgres:
   username:

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -72,6 +72,7 @@ azureKeyVaultName:
 secrets:
   type: memory
   ssmPath:
+  gsmPath:
 
 workers:
   env:

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -96,16 +96,16 @@ workers:
 redis:
   port: 6379
   ssl: false
-  host:
-  password:
+  host: ""
+  password: ""
   dbIndex: 0
   clusterMode: false
   zoneSuffix: us-east-1c
 
 postgres:
-  username:
-  password:
-  url:
+  username: ""
+  password: ""
+  url: ""
 
 conductor:
   env: {}
@@ -119,7 +119,7 @@ imageCredentials:
   registry: https://index.docker.io/v1/
   username: orkesdocker
   email: dockeracess@orkes.io
-  password:
+  password: ""
 
 # Set this to false if you will be setting environment variables in other ways
 useOrkesDeploymentSecrets: true
@@ -137,8 +137,8 @@ security:
   jwtExpiry: 3600
 # Please note that the admin user has to login first and create this group
   defaultUserGroupsOnCreate: all_users
-  defaultUserEmail:
-  defaultUserName:
+  defaultUserEmail: ""
+  defaultUserName: ""
   # Secret used to sign JWTs. How to generate it? openssl rand -base64 172 | tr -d '\n'
   jwt:
     secret: ""

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -71,8 +71,11 @@ azureKeyVaultName:
 
 secrets:
   type: memory
-  ssmPath:
-  gsmPath:
+  ssmPath: ""
+  gsmPath: ""
+
+serviceAccount:
+  annotations: {}
 
 workers:
   env:


### PR DESCRIPTION
  - Adds cloud secret manager support (gcp/ssm/azkv) with optional paths; when set, values are injected directly and the chart skips creating orkesdeploymentsecrets. Otherwise, the
  existing Secret path is used.
  - Exposes annotations on both Services and ServiceAccounts. Makes Redis zone suffix configurable instead of hard‑coded. Restores conditional “security,” prefix in SPRING_PROFILES_ACTIVE
  for app and workers. Keeps workers’ server URL overridable via workers.env.
  - Cleans up values/schema: adds empty‑string defaults, extends values.schema.json for new fields and the gcp type.