### PR TITLE
Update Conductor to 5.2.0

### DIFF
--- a/charts/orkes-conductor-standalone/Chart.yaml
+++ b/charts/orkes-conductor-standalone/Chart.yaml
@@ -4,5 +4,5 @@ description: Orkes Conductor Standalone (recommended only for testing and develo
 
 type: application
 
-version: 2.7.39
-appVersion: "5.2.16"
+version: 2.7.40
+appVersion: "5.2.20"

--- a/charts/orkes-conductor/Chart.yaml
+++ b/charts/orkes-conductor/Chart.yaml
@@ -4,5 +4,5 @@ description: Orkes Conductor
 
 type: application
 
-version: 2.7.38
-appVersion: "5.2.16"
+version: 2.7.40
+appVersion: "5.2.20"

--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -340,6 +340,12 @@ spec:
               value: {{ .Values.app.apiRateLimiterEnabled | quote }}
             - name: conductor.human-task.enabled
               value: {{ .Values.app.humanTasksEnabled | default "false" | quote }}
+            - name: conductor.app.workflow.introspection.enabled
+              value: {{ .Values.app.workflowIntrospection.enabled | default "false" | quote }}
+            - name: conductor.app.workflow.introspection.recordExpirationInSeconds
+              value: {{ .Values.app.workflowIntrospection.recordExpirationInSeconds | default 86400 | quote }}
+            - name: conductor.app.workflow.introspection.batchInsertIntervalInMillis
+              value: {{ .Values.app.workflowIntrospection.batchInsertIntervalInMillis | default 1000 | quote }}
             - name: LOCAL_HOST_IP
               valueFrom:
                 fieldRef:

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -162,6 +162,8 @@ security:
 #    audience:
 #    metadataUrl:
 #    emailClaim:
+#  # Note: native Okta integration is not officially deprecated, but we recommend using OIDC instead. The OIDC integration
+#  # is much more flexible, more commonly used, and is going to be more actively maintained in the future.
 #  okta:
 #    clientId:
 #    audience:

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -67,7 +67,7 @@ app:
   # production environments due to the high volume of data generated and increased load on the database.
   workflowIntrospection:
     enabled: false
-    recordExpirationInSeconds: 86400 # 1 day
+    recordExpirationInSeconds: 86400  # 1 day
     batchInsertIntervalInMillis: 1000
 
 # Provide the name of the key vault if you are using key vault for secret management

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -62,6 +62,13 @@ app:
   taskDefinitionCache:
     refreshIntervalInSeconds: 60  # Task definitions are cached by default
     maxSize: 1000
+  # Workflow introspection is disabled by default. This feature allows you to record and query detailed execution of
+  # workflows for debugging and performance analysis (essentially, it adds flame graphs). It is not recommended in
+  # production environments due to the high volume of data generated and increased load on the database.
+  workflowIntrospection:
+    enabled: false
+    recordExpirationInSeconds: 86400 # 1 day
+    batchInsertIntervalInMillis: 1000
 
 # Provide the name of the key vault if you are using key vault for secret management
 # Pre-requisite - the Azure SDK used by Conductor expects the host (i.e. pod/container) to be able to access this vault


### PR DESCRIPTION
Updates Conductor to 5.2.0, adds properties for enabling flame graphs, and adds a disclaimer to customers to avoid the Okta authentication provider.