### PR TITLE
Allow naming overrides

### DIFF
--- a/charts/orkes-conductor/templates/deployment.yaml
+++ b/charts/orkes-conductor/templates/deployment.yaml
@@ -13,7 +13,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-conductor
+  name: {{ default "orkes-conductor-deployment" .Values.conductor.deploymentName }}
   labels:
     app.kubernetes.io/name: orkes-conductor
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -61,6 +61,8 @@ spec:
                   fieldPath: status.podIP
             - name: SPRING_PROFILES_ACTIVE
               value: logrotate,postgres
+            - name: DEPLOY_ENV
+              value: prod
             - name: ORKES_CLUSTER_NAME
               value: {{ default .Release.Name .Values.clusterName }}
             {{- if .Values.conductor.env }}
@@ -86,7 +88,7 @@ spec:
           startupProbe:
             httpGet:
               path: /health
-              port: ui
+              port: api
             failureThreshold: 30
             periodSeconds: 10
           volumeMounts:
@@ -117,7 +119,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-workers
+  name: {{ default "orkes-workers-deployment" .Values.workers.deploymentName }}
   labels:
     app.kubernetes.io/name: orkes-conductor
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -158,6 +160,8 @@ spec:
                 -XX:+ExitOnOutOfMemoryError
             - name: ORKES_CLUSTER_NAME
               value: {{ default .Release.Name .Values.clusterName }}
+            - name: DEPLOY_ENV
+              value: prod
             {{- if .Values.workers.env }}
             {{- range $key, $value := .Values.workers.env }}
             - name: {{ $key }}

--- a/charts/orkes-conductor/templates/properties.yaml
+++ b/charts/orkes-conductor/templates/properties.yaml
@@ -46,10 +46,10 @@ metadata:
 data:
   config.properties: |
     {{- if eq (kindOf .Values.conductor.properties) "string" }}
-    {{ .Values.conductor.properties | nindent 4 }}
+    {{- .Values.conductor.properties | nindent 4 }}
     {{- else }}
     {{- range $k, $v := .Values.conductor.properties }}
-    {{ $v | nindent 4 }}
+    {{- $v | nindent 4 }}
     {{- end }}
     {{- end }}
 ---
@@ -66,9 +66,9 @@ metadata:
 data:
   config.properties: |
     {{- if eq (kindOf .Values.workers.properties) "string" }}
-    {{ .Values.workers.properties | nindent 4 }}
+    {{- .Values.workers.properties | nindent 4 }}
     {{- else }}
     {{- range $k, $v := .Values.workers.properties }}
-    {{ $v | nindent 4 }}
+    {{- $v | nindent 4 }}
     {{- end }}
     {{- end }}

--- a/charts/orkes-conductor/templates/service.yaml
+++ b/charts/orkes-conductor/templates/service.yaml
@@ -1,7 +1,29 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-server
+  name: {{ default "conductor" .Values.conductor.uiServiceName }}
+  labels:
+    app.kubernetes.io/name: orkes-conductor
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: app
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: ui
+      port: {{ .Values.conductor.ports.ui }}
+      targetPort: 5000
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: orkes-conductor
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ default "conductor-app" .Values.conductor.appServiceName }}
   labels:
     app.kubernetes.io/name: orkes-conductor
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -14,10 +36,6 @@ spec:
     - name: api
       port: {{ .Values.conductor.ports.api }}
       targetPort: 8080
-      protocol: TCP
-    - name: ui
-      port: {{ .Values.conductor.ports.ui }}
-      targetPort: 5000
       protocol: TCP
   selector:
     app.kubernetes.io/name: orkes-conductor


### PR DESCRIPTION
* Allow complete name overrides for server and worker deployment and service names, defaulting to names used by cloud deployments to align with agent assumptions
* Modify startup probe port from `ui` to `api` for compatibility with API Gateway
* Add default `DEPLOY_ENV=prod` env var for both deployments to prevent AWS SSM client from using local credentials
* Trim properties content in config maps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Kubernetes resource naming and Service topology changes can break existing DNS references/ingress routing and require coordination during upgrades, though changes are localized to Helm templates.
> 
> **Overview**
> Adds Helm values to **override Deployment/Service names** for Conductor and workers (defaulting to cloud-aligned names) instead of hardcoding `{{ .Release.Name }}`-derived names.
> 
> Splits the Conductor Service into separate UI and API Services (UI-only `conductor` plus API-only `conductor-app`), switches the Conductor `startupProbe` to hit the `api` port, and injects default `DEPLOY_ENV=prod` into both server and worker pods.
> 
> Trims/normalizes properties ConfigMap rendering by using whitespace-trimming templating so `config.properties` content is emitted cleanly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fe0d7e7070f42080a3adf9c17477c5d964bfc4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->