### PR TITLE
Bump versions for release

### DIFF
--- a/charts/orkes-conductor/Chart.yaml
+++ b/charts/orkes-conductor/Chart.yaml
@@ -4,5 +4,5 @@ description: Orkes Conductor
 
 type: application
 
-version: 3.0.1
-appVersion: "5.2.76"
+version: 3.0.2
+appVersion: "5.2.78"


### PR DESCRIPTION
Chart -> 3.0.2
Conductor -> 5.2.78

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bumps in `Chart.yaml` with no logic changes; risk is limited to pulling/deploying the new app image version.
> 
> **Overview**
> Bumps the Helm chart metadata for `orkes-conductor` to release `version: 3.0.2` and updates the deployed application `appVersion` to `5.2.78`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cebf07370f7f502390f016e7107b1803543051ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->