### PR TITLE
Custom service names and pod monitors

### DIFF
--- a/charts/orkes-conductor/templates/ingress.yaml
+++ b/charts/orkes-conductor/templates/ingress.yaml
@@ -10,7 +10,10 @@
   {{- end -}}
 {{- end -}}
 
-{{- range $name, $config := $ingresses -}}
+{{- $uiServiceName := default "conductor" .Values.conductor.uiServiceName -}}
+{{- $apiServiceName := default "conductor-app" .Values.conductor.appServiceName -}}
+
+{{- range $name, $config := $ingresses }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -22,41 +25,31 @@ metadata:
     app.kubernetes.io/component: app
     app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     app.kubernetes.io/managed-by: Helm
-  {{- with $config.annotations }}
+{{- if $config.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+{{ toYaml $config.annotations | nindent 4 }}
+{{- end }}
 spec:
-  {{- if $config.className }}
+{{- if $config.className }}
   ingressClassName: {{ $config.className }}
-  {{- end }}
-  {{- if $config.tls }}
+{{- end }}
+{{- if $config.tls }}
   tls:
-    {{- range $config.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
+{{ toYaml $config.tls | nindent 4 }}
+{{- end }}
   rules:
-    {{- range $config.hosts }}
+{{- range $config.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+{{- range .paths }}
           - path: {{ .path }}
-            {{- if .pathType }}
-            pathType: {{ .pathType }}
-            {{- else }}
-            pathType: Prefix
-            {{- end }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
               service:
-                name: {{ $.Release.Name }}-server
+                name: {{ if or (hasPrefix "/api" .path) (hasPrefix "/swagger-ui" .path) (hasPrefix "/api-docs" .path) (hasPrefix "/v3/api-docs" .path) }}{{ $apiServiceName }}{{ else }}{{ $uiServiceName }}{{ end }}
                 port:
                   number: {{ .port }}
-          {{- end }}
-    {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/orkes-conductor/templates/monitor.yaml
+++ b/charts/orkes-conductor/templates/monitor.yaml
@@ -1,0 +1,62 @@
+{{- /*
+Create a PodMonitor or ServiceMonitor to enable Prometheus to scrape Conductor metrics.
+This requires the Prometheus Operator CRDs (installed by kube-prometheus-stack).
+*/ -}}
+
+{{- if and .Values.conductor.metrics .Values.conductor.metrics.enabled -}}
+{{- $kind := default "PodMonitor" .Values.conductor.metrics.kind -}}
+
+{{- if eq $kind "PodMonitor" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-conductor
+  labels:
+    app.kubernetes.io/name: orkes-conductor
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: app
+    {{- with .Values.conductor.metrics.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orkes-conductor
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: app
+  podMetricsEndpoints:
+    - port: {{ default "api" .Values.conductor.metrics.portName | quote }}
+      path: {{ default "/actuator/prometheus" .Values.conductor.metrics.path | quote }}
+      interval: {{ default "5s" .Values.conductor.metrics.interval | quote }}
+      scrapeTimeout: {{ default "5s" .Values.conductor.metrics.scrapeTimeout | quote }}
+      scheme: {{ default "http" .Values.conductor.metrics.scheme | quote }}
+
+{{- else if eq $kind "ServiceMonitor" }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-conductor
+  labels:
+    app.kubernetes.io/name: orkes-conductor
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: app
+    {{- with .Values.conductor.metrics.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orkes-conductor
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: app
+  endpoints:
+    - port: {{ default "api" .Values.conductor.metrics.portName | quote }}
+      path: {{ default "/actuator/prometheus" .Values.conductor.metrics.path | quote }}
+      interval: {{ default "5s" .Values.conductor.metrics.interval | quote }}
+      scrapeTimeout: {{ default "5s" .Values.conductor.metrics.scrapeTimeout | quote }}
+      scheme: {{ default "http" .Values.conductor.metrics.scheme | quote }}
+
+{{- else }}
+{{- fail (printf "Unsupported conductor.metrics.kind=%s (expected PodMonitor or ServiceMonitor)" $kind) -}}
+{{- end }}
+{{- end }}

--- a/charts/orkes-conductor/templates/monitor.yaml
+++ b/charts/orkes-conductor/templates/monitor.yaml
@@ -15,6 +15,8 @@ metadata:
     app.kubernetes.io/name: orkes-conductor
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: app
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/managed-by: Helm
     {{- with .Values.conductor.metrics.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -40,6 +42,8 @@ metadata:
     app.kubernetes.io/name: orkes-conductor
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: app
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/managed-by: Helm
     {{- with .Values.conductor.metrics.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/orkes-conductor/values.yaml
+++ b/charts/orkes-conductor/values.yaml
@@ -107,6 +107,25 @@ conductor:
   # NOTE: These values will override any equivalent settings in the properties file.
   env: {}
 
+  # Metrics scraping configuration for kube-prometheus-stack.
+  # When enabled, the chart will create a PodMonitor (recommended) so Prometheus scrapes each Conductor pod directly.
+  metrics:
+    enabled: false
+    # One of: PodMonitor, ServiceMonitor
+    kind: PodMonitor
+    # Scrape settings
+    path: /actuator/prometheus
+    interval: 5s
+    scrapeTimeout: 5s
+    scheme: http
+    # Name of the container port to scrape (must match a named container port in the Deployment).
+    portName: api
+    # Additional labels to attach to the monitor resource.
+    # If your Prometheus is configured with a label selector, you might need:
+    # labels:
+    #   release: prometheus
+    labels: {}
+
 # These properties configure the deployment of Orkes' built-in workers, not any
 # custom workers you may have.
 workers:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Ingress backend selection changes can alter routing behavior and break deployments if service names/paths don’t match expectations; the monitor resources are additive and gated behind an explicit enable flag.
> 
> **Overview**
> Adds optional Prometheus Operator integration by rendering a `PodMonitor` (default) or `ServiceMonitor` when `conductor.metrics.enabled` is set, with configurable scrape settings and labels.
> 
> Updates `ingress.yaml` to (1) simplify `annotations`/`tls` rendering and default `pathType`, and (2) route requests to configurable UI vs API service names based on path prefixes (e.g., `/api`, `/swagger-ui`, `/api-docs`, `/v3/api-docs`) instead of always targeting the prior single backend service.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c7944ddcf854cc2fedbf45cfdb9c990307c6ba7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->